### PR TITLE
Implement a Set lookup as described in #34

### DIFF
--- a/bit.ts
+++ b/bit.ts
@@ -155,8 +155,8 @@ export class Bit {
         } else {
             this.slpMempoolIgnoreList.push(txid);
             this.slpMempoolIgnoreSet.add(txid);
-            if(this.slpMempoolIgnoreList.length > 10000) {
-                this.slpMempoolIgnoreSet.delete(this.slpMempoolIgnoreList.shift());
+            if(this.slpMempoolIgnoreList.length > Config.core.slp_mempool_ignore_length) {
+                this.slpMempoolIgnoreSet.delete(this.slpMempoolIgnoreList.shift()!);
             }
         }
         return { isSlp: false, added: false };

--- a/config.ts
+++ b/config.ts
@@ -81,6 +81,7 @@ export class Config {
 	}
 	static core = {
 		from: Number.parseInt(process.env.core_from ? process.env.core_from : "543375"),
-		from_testnet: Number.parseInt(process.env.core_from ? process.env.core_from : "1253801")
+		from_testnet: Number.parseInt(process.env.core_from ? process.env.core_from : "1253801"),
+		slp_mempool_ignore_length: Number.parseInt(process.env.core_slp_mempool_ignore_length ? process.env.core_slp_mempool_ignore_length : "1000000"),
 	}
 }


### PR DESCRIPTION
I have synced from genesis with it and ran a few blocks through... it does "seem to work" and implements the idea described in #34 + it's a pretty simple change, however this is the extent of my testing with it so would be good to have another set of eyes look at it. 

This defaults to 1 million entries, allowing over blocks larger than 32mb today. It can be modified with environment variables like the rest of config if this is too high or low for some use-cases. 

As a side note: It might be smart to augment this with regards to `removeMempoolTransaction` or other bits of code when a block is confirmed, this way we can minimize the size of the List and of the Set having them only balloon during big (future) blocks. I don't think we need to keep them around after a block has included them. 